### PR TITLE
[Fix] 纠正了在 ParserGroupReplyMsg() 判断 type 为 "AtMsg" 的问题，更改为判断 type 是否为…

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,8 @@ func (a AtMsg) Clean() AtMsg {
 	return a
 }
 func ParserGroupReplyMsg(pack GroupMsgPack) (a Reply, e error) {
-	if pack.MsgType != "AtMsg" {
+	// Why OPQbot returns "replay" ...???
+	if pack.MsgType != "ReplayMsg" {
 		e = errors.New("Not ReplyMsg. ")
 		return
 	}


### PR DESCRIPTION
纠正了在 ParserGroupReplyMsg() 判断 type 为 "AtMsg" 的问题，但是事实上回复不一定需要艾特人，更改为判断 type 是否为 "ReplayMsg"
并且发现来自 Bot 本体的 typo："Replay"，只能将错就错写 Replay 了